### PR TITLE
feat: アニメーションの完了よりも先にスコア加算を行うように変更

### DIFF
--- a/Assets/JJJ/Core/Interfaces/ITurnExecutor.cs
+++ b/Assets/JJJ/Core/Interfaces/ITurnExecutor.cs
@@ -23,8 +23,8 @@ namespace JJJ.Core.Interfaces
     /// <param name="judgeInput">ジャッジ入力</param>
     /// <param name="timerService">タイマーサービス</param>
     /// <param name="cancellationToken">キャンセルトークン</param>
-    /// <returns>ターンの結果を通知するObservable</returns>
-    public UniTask<TurnOutcome> ExecuteTurn(IRuleSet ruleSet,
+    /// <returns>ターンの結果と手のアニメーションが完了するまで待機するUniTaskのタプル</returns>
+    public UniTask<(TurnOutcome, UniTask)> ExecuteTurn(IRuleSet ruleSet,
                                          ICpuHandStrategy playerStrategy,
                                          ICpuHandStrategy opponentStrategy,
                                          TurnContext context,

--- a/Assets/JJJ/Infrastructure/ReactiveTurnExecutor.cs
+++ b/Assets/JJJ/Infrastructure/ReactiveTurnExecutor.cs
@@ -19,7 +19,7 @@ namespace JJJ.UseCase.Turn
 
     private readonly Microsoft.Extensions.Logging.ILogger _logger = LogManager.CreateLogger<ReactiveTurnExecutor>();
 
-    public async UniTask<TurnOutcome> ExecuteTurn(IRuleSet ruleSet,
+    public async UniTask<(TurnOutcome, UniTask)> ExecuteTurn(IRuleSet ruleSet,
                                                 ICpuHandStrategy playerStrategy,
                                                 ICpuHandStrategy opponentStrategy,
                                                 TurnContext context,
@@ -108,10 +108,8 @@ namespace JJJ.UseCase.Turn
         timerRemainsPresenter.SetTimerRemains((float)limit.TotalSeconds, (float)limit.TotalSeconds);
       }
       
-      // 手のアニメーションが完了するまで待機
-      await UniTask.WhenAll(playerHandPlayTask, opponentHandPlayTask);
       _disposables = new CompositeDisposable { timerObservable };
-      return outcome;
+      return (outcome, UniTask.WhenAll(playerHandPlayTask, opponentHandPlayTask));
     }
 
     public void Dispose()

--- a/Assets/JJJ/UseCase/JudgeService.cs
+++ b/Assets/JJJ/UseCase/JudgeService.cs
@@ -176,9 +176,10 @@ namespace JJJ.UseCase
         }
 
         // 1ターン実行
-        var outcome = await _turnExecutor.ExecuteTurn(_ruleSet, _currentPlayerStrategy, _currentOpponentStrategy, _currentTurnContext,
+        var (outcome, handAnimationTask) = await _turnExecutor.ExecuteTurn(_ruleSet, _currentPlayerStrategy, _currentOpponentStrategy, _currentTurnContext,
                         _judgeLimit, _compositeHandAnimationPresenter, _timerRemainsPresenter, _judgeInput, _timerService, cancellationToken);
-        // TODO: Viewへ手・結果通知（outcome.TruthResult, outcome.Claim, outcome.IsPlayerJudgementCorrect）
+        
+
         _logger.ZLogTrace($"JudgeService: TurnOutcome - Truth: {outcome.TruthResult.Type}, Claim: {outcome.Claim}, Correct: {outcome.IsPlayerJudgementCorrect}, JudgeTime: {outcome.JudgeTime}");
 
         // 点数を加算
@@ -187,6 +188,9 @@ namespace JJJ.UseCase
         if (_currentScore < 0) _currentScore = 0;
         _currentScorePresenter.SetCurrentScore(_currentScore);
         _currentScorePresenter.SetScoreDiff(scoreDiff);
+
+        // 手のアニメーションが完了するまで待機
+        await handAnimationTask;
 
         // ジャッジ回数を更新
         _judgeCount++;


### PR DESCRIPTION
## About
- close #49 
- `ITurnExecutor.ExecuteTurn`の返り値を変更し、スコアを加算したあとに手のアニメーションの完了を待機するように変更